### PR TITLE
Refactor namespaces to DockingWidget

### DIFF
--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Models/JobModel.cs
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Models/JobModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace SimpleDragAndDropWithBlazor.Models
+namespace DockingWidget.Models
 {
     public class JobModel
     {

--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Pages/_Host.cshtml
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Pages/_Host.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "/"
-@namespace SimpleDragAndDropWithBlazor.Pages
+@namespace DockingWidget.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
 <!DOCTYPE html>
@@ -7,7 +7,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Simple Drag And Drop With Blazor</title>
+    <title>Docking Widget</title>
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/site.css" rel="stylesheet" />

--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Program.cs
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Program.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace SimpleDragAndDropWithBlazor
+namespace DockingWidget
 {
     public class Program
     {

--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Shared/MainLayout.razor
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Shared/MainLayout.razor
@@ -2,7 +2,7 @@
 
 <div class="main">
     <div class="top-row px-4">
-        <h3>Simple drag and drop with Blazor</h3>
+        <h3>Docking Widget</h3>
         <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
     </div>
 

--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor.csproj
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>DockingWidget</RootNamespace>
+    <AssemblyName>DockingWidget</AssemblyName>
   </PropertyGroup>
 
 </Project>

--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Startup.cs
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/Startup.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace SimpleDragAndDropWithBlazor
+namespace DockingWidget
 {
     public class Startup
     {

--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/_Imports.razor
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/_Imports.razor
@@ -4,6 +4,6 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
-@using SimpleDragAndDropWithBlazor
-@using SimpleDragAndDropWithBlazor.Shared
-@using SimpleDragAndDropWithBlazor.Models
+@using DockingWidget
+@using DockingWidget.Shared
+@using DockingWidget.Models

--- a/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/wwwroot/css/site.css
+++ b/SimpleDragAndDropWithBlazor/SimpleDragAndDropWithBlazor/wwwroot/css/site.css
@@ -115,7 +115,7 @@ app {
     color: red;
 }
 
-/** Simple drag and drop with Blazor CSS **/
+/** Docking Widget CSS **/
 
 .jobs-container {
     display: flex;


### PR DESCRIPTION
## Summary
- rename namespaces from `SimpleDragAndDropWithBlazor` to `DockingWidget`
- adjust imports and root namespace
- update layout title and CSS comment

## Testing
- `dotnet build SimpleDragAndDropWithBlazor.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688b9ca42624832c956fb29d48fd13a2