### PR TITLE
Add simple Blazor dock layout example

### DIFF
--- a/DockingWidget/DockingWidget/Docking/DockLayout.razor
+++ b/DockingWidget/DockingWidget/Docking/DockLayout.razor
@@ -1,0 +1,17 @@
+@using DockingWidget.Docking
+@inject IDockService DockService
+
+<CascadingValue Value="this">
+    <div class="dock-layout">
+        <div class="top"><DockZone Zone="DockZoneType.Top" /></div>
+        <div class="left"><DockZone Zone="DockZoneType.Left" /></div>
+        <div class="center"><DockZone Zone="DockZoneType.Center" /></div>
+        <div class="right"><DockZone Zone="DockZoneType.Right" /></div>
+        <div class="bottom"><DockZone Zone="DockZoneType.Bottom" /></div>
+    </div>
+</CascadingValue>
+
+@code {
+    public PanelModel DraggedPanel { get; set; }
+    public IDockService Service => DockService;
+}

--- a/DockingWidget/DockingWidget/Docking/DockPanel.razor
+++ b/DockingWidget/DockingWidget/Docking/DockPanel.razor
@@ -1,0 +1,16 @@
+@inherits LayoutComponentBase
+@using DockingWidget.Docking
+
+<div class="dock-panel" draggable="true" @ondragstart="OnDragStart">
+    <h5>@Panel.Title</h5>
+</div>
+
+@code {
+    [CascadingParameter] public DockLayout Layout { get; set; }
+    [Parameter] public PanelModel Panel { get; set; }
+
+    private void OnDragStart()
+    {
+        Layout.DraggedPanel = Panel;
+    }
+}

--- a/DockingWidget/DockingWidget/Docking/DockService.cs
+++ b/DockingWidget/DockingWidget/Docking/DockService.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DockingWidget.Docking
+{
+    public class DockService : IDockService
+    {
+        private readonly List<PanelModel> _panels = new List<PanelModel>
+        {
+            new PanelModel { Title = "Panel 1", Zone = DockZoneType.Left },
+            new PanelModel { Title = "Panel 2", Zone = DockZoneType.Right },
+            new PanelModel { Title = "Panel 3", Zone = DockZoneType.Bottom }
+        };
+
+        public IEnumerable<PanelModel> GetPanels(DockZoneType zone)
+        {
+            return _panels.Where(p => p.Zone == zone);
+        }
+
+        public void MovePanel(PanelModel panel, DockZoneType zone)
+        {
+            var target = _panels.FirstOrDefault(p => p.Id == panel.Id);
+            if (target != null)
+            {
+                target.Zone = zone;
+            }
+        }
+    }
+}

--- a/DockingWidget/DockingWidget/Docking/DockZone.razor
+++ b/DockingWidget/DockingWidget/Docking/DockZone.razor
@@ -1,0 +1,24 @@
+@using DockingWidget.Docking
+
+<div class="dock-zone" @ondrop="HandleDrop" @ondragover:preventDefault="true">
+    @foreach (var panel in Panels)
+    {
+        <DockPanel Panel="panel" />
+    }
+</div>
+
+@code {
+    [CascadingParameter] public DockLayout Layout { get; set; }
+    [Parameter] public DockZoneType Zone { get; set; }
+
+    private IEnumerable<PanelModel> Panels => Layout.Service.GetPanels(Zone);
+
+    private void HandleDrop()
+    {
+        if (Layout.DraggedPanel != null)
+        {
+            Layout.Service.MovePanel(Layout.DraggedPanel, Zone);
+            Layout.DraggedPanel = null;
+        }
+    }
+}

--- a/DockingWidget/DockingWidget/Docking/DockZoneType.cs
+++ b/DockingWidget/DockingWidget/Docking/DockZoneType.cs
@@ -1,0 +1,11 @@
+namespace DockingWidget.Docking
+{
+    public enum DockZoneType
+    {
+        Top,
+        Bottom,
+        Left,
+        Right,
+        Center
+    }
+}

--- a/DockingWidget/DockingWidget/Docking/IDockService.cs
+++ b/DockingWidget/DockingWidget/Docking/IDockService.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace DockingWidget.Docking
+{
+    public interface IDockService
+    {
+        IEnumerable<PanelModel> GetPanels(DockZoneType zone);
+        void MovePanel(PanelModel panel, DockZoneType zone);
+    }
+}

--- a/DockingWidget/DockingWidget/Docking/PanelModel.cs
+++ b/DockingWidget/DockingWidget/Docking/PanelModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DockingWidget.Docking
+{
+    public class PanelModel
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Title { get; set; }
+        public DockZoneType Zone { get; set; }
+    }
+}

--- a/DockingWidget/DockingWidget/Pages/Index.razor
+++ b/DockingWidget/DockingWidget/Pages/Index.razor
@@ -10,6 +10,9 @@
 <p>Last updated job was: <strong>@lastUpdatedJob</strong></p>
 <hr />
 
+<h3>Dock Layout Demo</h3>
+<DockLayout />
+
 @foreach (var task in Jobs)
 {
     <p>@task.Description - <strong>@task.Status</strong></p>

--- a/DockingWidget/DockingWidget/SimpleDragAndDropWithBlazor.csproj
+++ b/DockingWidget/DockingWidget/SimpleDragAndDropWithBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>DockingWidget</RootNamespace>
     <AssemblyName>DockingWidget</AssemblyName>
   </PropertyGroup>

--- a/DockingWidget/DockingWidget/Startup.cs
+++ b/DockingWidget/DockingWidget/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using DockingWidget.Docking;
 
 namespace DockingWidget
 {
@@ -23,6 +24,7 @@ namespace DockingWidget
             services.AddServerSideBlazor(config => {
                 config.DetailedErrors = true;
             });
+            services.AddSingleton<IDockService, DockService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/DockingWidget/DockingWidget/_Imports.razor
+++ b/DockingWidget/DockingWidget/_Imports.razor
@@ -7,3 +7,4 @@
 @using DockingWidget
 @using DockingWidget.Shared
 @using DockingWidget.Models
+@using DockingWidget.Docking

--- a/DockingWidget/DockingWidget/wwwroot/css/site.css
+++ b/DockingWidget/DockingWidget/wwwroot/css/site.css
@@ -214,8 +214,40 @@ app {
         display: none;
     }
 
-    .sidebar .collapse {
+.sidebar .collapse {
         /* Never collapse the sidebar for wide screens */
         display: block;
     }
+}
+
+/* Dock layout styles */
+.dock-layout {
+    display: grid;
+    grid-template-areas:
+        "top top top"
+        "left center right"
+        "bottom bottom bottom";
+    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-rows: 80px 1fr 80px;
+    gap: 10px;
+}
+
+.dock-layout .top { grid-area: top; }
+.dock-layout .bottom { grid-area: bottom; }
+.dock-layout .left { grid-area: left; }
+.dock-layout .right { grid-area: right; }
+.dock-layout .center { grid-area: center; }
+
+.dock-zone {
+    border: 1px dashed #75868a;
+    min-height: 60px;
+    padding: 5px;
+}
+
+.dock-panel {
+    background: #5c6b7f;
+    color: #fff;
+    padding: 5px;
+    margin-bottom: 5px;
+    cursor: grab;
 }


### PR DESCRIPTION
## Summary
- enable .NET 8 target for sample project
- implement dock layout service and components
- register dock service in DI and render the layout on the index page
- style dock zones and panels

## Testing
- `dotnet build DockingWidget/SimpleDragAndDropWithBlazor.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688ba24a5c0c832cb7dc9bcb6b577ab5