### PR TITLE
Remove layout gap and auto resize zones

### DIFF
--- a/DockingWidget/DockingWidget/wwwroot/css/site.css
+++ b/DockingWidget/DockingWidget/wwwroot/css/site.css
@@ -227,9 +227,9 @@ app {
         "top top top"
         "left center right"
         "bottom bottom bottom";
-    grid-template-columns: 1fr 2fr 1fr;
-    grid-template-rows: 80px 1fr 80px;
-    gap: 10px;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto 1fr auto;
+    gap: 0;
 }
 
 .dock-layout .top { grid-area: top; }
@@ -240,8 +240,13 @@ app {
 
 .dock-zone {
     border: 1px dashed #75868a;
-    min-height: 60px;
+    min-height: 0;
     padding: 5px;
+}
+
+.dock-zone:empty {
+    border: none;
+    padding: 0;
 }
 
 .dock-panel {


### PR DESCRIPTION
## Summary
- grid columns/rows and gap modifications so zones resize when empty
- zero spacing between dock zones
- hide empty zones

## Testing
- `dotnet test DockingWidget.Tests/DockingWidget.Tests.csproj -v minimal` *(fails: Unable to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_688be0c89330832cbad3458d3084ef29